### PR TITLE
Feature: Tkinter widget overlay to tell if mouse yoke is active / Fix pyautogui failsafe issues

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "master_key": ",",
     "throttle_sensitivity": 20,
     "remember_last_position": true,
-    "center_xy_axes_key": "."
+    "center_xy_axes_key": ".",
+    "display_gui": true
 }

--- a/mouse_yoke.py
+++ b/mouse_yoke.py
@@ -1,4 +1,6 @@
 from pyautogui import size, moveTo
+import pyautogui
+
 from pynput import mouse, keyboard
 from reprint import output
 from threading import Thread
@@ -145,6 +147,8 @@ class ColorDisplayApp:
 
 
 def runTK():
+    if(not configs['display_gui']):
+        return
     root = tk.Tk()
     app = ColorDisplayApp(root)
     root.mainloop()
@@ -153,6 +157,7 @@ if __name__ == "__main__":
     logging.warning("mouse_yoke.py is now running\n\n")
 
     try:
+        pyautogui.FAILSAFE = False
         ui = Thread(target=userInterface)
         ms = mouse.Listener(on_move=mouseYoke, on_scroll=throttle)
         kb = keyboard.Listener(on_release=onKeyRelease)

--- a/mouse_yoke.py
+++ b/mouse_yoke.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import json
 import time
+import tkinter as tk
 
 
 with open("./config.json") as config_file:
@@ -108,6 +109,46 @@ def userInterface():
             time.sleep(0.05)
 
 
+class ColorDisplayApp:
+    def __init__(self, master):
+        self.master = master
+        self.master.title("Mouse Yoke")
+        self.master.geometry("100x50")
+
+        self.namelabel = tk.Label(self.master, text="Mouse Yoke", font=('Consolas', 8) , anchor="center", justify="center")
+        self.label = tk.Label(self.master, text="", font=('Consolas', 16), anchor="center", justify="center")
+        self.namelabel.pack(pady=0)
+        self.label.pack(pady=0)
+
+        self.master.after(100, self.update_display)
+        
+        self.master.attributes('-topmost', True)
+        self.master.overrideredirect(True)
+
+
+    def update_display(self):
+        if active:
+            self.label.config(bg="red")
+            self.master.configure(bg="red")
+
+            self.label.config(text = "ACTIVE")
+            self.master.attributes('-alpha', 1)
+        else:
+            
+            self.label.config(bg="gray")
+            self.master.configure(bg="gray")
+
+            self.label.config(text = "")
+            self.master.attributes('-alpha', 0.5)
+        self.master.after(100, self.update_display)
+
+
+
+def runTK():
+    root = tk.Tk()
+    app = ColorDisplayApp(root)
+    root.mainloop()
+
 if __name__ == "__main__":
     logging.warning("mouse_yoke.py is now running\n\n")
 
@@ -115,12 +156,15 @@ if __name__ == "__main__":
         ui = Thread(target=userInterface)
         ms = mouse.Listener(on_move=mouseYoke, on_scroll=throttle)
         kb = keyboard.Listener(on_release=onKeyRelease)
+        tl = Thread(target=runTK)
         
         ms.start()
         kb.start()
         ui.start()
+        tl.start()
         ms.join()
         kb.join()
+        tl.join()
 
     except Exception as e:
         logging.critical("Exception occurred", exc_info=True)


### PR DESCRIPTION
This PR adds a Tkinter widget on the top-left corner of the display which tells if the mouse yoke is active. Additionally, it fixes #5  by disabling pyautogui's FAILSAFE.

![11](https://github.com/matiaspedelhez/msfs_mouse_yoke/assets/77095432/cde06401-cbda-4a62-a7b2-0b0c2729d0a5)
![12](https://github.com/matiaspedelhez/msfs_mouse_yoke/assets/77095432/29c8eedf-8151-49f3-a12e-a794d735e145)

- This is useful as currently there is no way to tell if the mouse yoke is active during flight except bringing up the console every time/ turning the plane, leading to undesirable inputs.
- Tkinter is built-in with python so there would be no additional dependencies.
- A `display_gui` entry in config.json can be used to turn the widget on/off.
- It also fixes #5 by setting `pyautogui.FAILSAFE` to False at startup.

- Tested on Windows 11 w/ Python 3.10.10